### PR TITLE
Guidelines: Add the scopes registry, REST route, and row invariants

### DIFF
--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -792,10 +792,6 @@ add_filter( 'rest_wp_navigation_item_schema', array( 'WP_Navigation_Fallback', '
 // wp_knowledge post type.
 add_action( 'wp_after_insert_post', 'wp_knowledge_ensure_default_type_term', 10, 2 );
 add_filter( 'wp_insert_term_data', 'wp_knowledge_maybe_map_term_label', 10, 2 );
-
-// Guidelines, a wp_knowledge consumer. A single callback shapes a guideline row
-// on the REST insert path. For a slug that maps to a registered scope it forces
-// the guideline type, sets the title, and caps the content.
 add_filter( 'rest_pre_insert_wp_knowledge', 'wp_guideline_prepare_rest_row', 10, 2 );
 
 // Fluid typography.

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -793,13 +793,10 @@ add_filter( 'rest_wp_navigation_item_schema', array( 'WP_Navigation_Fallback', '
 add_action( 'wp_after_insert_post', 'wp_knowledge_ensure_default_type_term', 10, 2 );
 add_filter( 'wp_insert_term_data', 'wp_knowledge_maybe_map_term_label', 10, 2 );
 
-// Guidelines, a wp_knowledge consumer. The type reservation and scope-title
-// re-stamp are structural invariants enforced on every write path. The
-// reservation runs before the knowledge default-term fallback (priority 10) so it
-// can claim the type. Content sanitization shapes untrusted input over REST.
-add_action( 'save_post_wp_knowledge', 'wp_guideline_reserve_type_term', 9 );
-add_filter( 'wp_insert_post_data', 'wp_guideline_restamp_scope_title', 10, 2 );
-add_filter( 'rest_pre_insert_wp_knowledge', 'wp_guideline_sanitize_rest_content', 10, 2 );
+// Guidelines, a wp_knowledge consumer. A single callback shapes a guideline row
+// on the REST insert path. For a slug that maps to a registered scope it forces
+// the guideline type, sets the title, and caps the content.
+add_filter( 'rest_pre_insert_wp_knowledge', 'wp_guideline_prepare_rest_row', 10, 2 );
 
 // Fluid typography.
 add_filter( 'render_block', 'wp_render_typography_support', 10, 2 );

--- a/src/wp-includes/default-filters.php
+++ b/src/wp-includes/default-filters.php
@@ -793,6 +793,14 @@ add_filter( 'rest_wp_navigation_item_schema', array( 'WP_Navigation_Fallback', '
 add_action( 'wp_after_insert_post', 'wp_knowledge_ensure_default_type_term', 10, 2 );
 add_filter( 'wp_insert_term_data', 'wp_knowledge_maybe_map_term_label', 10, 2 );
 
+// Guidelines, a wp_knowledge consumer. The type reservation and scope-title
+// re-stamp are structural invariants enforced on every write path. The
+// reservation runs before the knowledge default-term fallback (priority 10) so it
+// can claim the type. Content sanitization shapes untrusted input over REST.
+add_action( 'save_post_wp_knowledge', 'wp_guideline_reserve_type_term', 9 );
+add_filter( 'wp_insert_post_data', 'wp_guideline_restamp_scope_title', 10, 2 );
+add_filter( 'rest_pre_insert_wp_knowledge', 'wp_guideline_sanitize_rest_content', 10, 2 );
+
 // Fluid typography.
 add_filter( 'render_block', 'wp_render_typography_support', 10, 2 );
 

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -17,11 +17,13 @@
 /**
  * Retrieves the registered guideline scopes, keyed by slug.
  *
- * Scopes are the sections shown on a Guidelines management screen. Each scope is
- * backed by at most one `guideline`-typed `wp_knowledge` row whose slug is
- * `guideline-{scope}`. Plugins can register their own scopes via the
- * {@see 'wp_guideline_scopes'} filter. The registry carries identity and
- * presentation only. Rows are created on first save.
+ * A scope groups guideline content under a stable key. Each scope is backed by
+ * at most one `guideline`-typed `wp_knowledge` row whose slug is
+ * `guideline-{scope}`. Rows are created on first save. Plugins can register or
+ * remove scopes via the {@see 'wp_guideline_scopes'} filter.
+ *
+ * The `blocks` scope is the one exception. It has no single `guideline-blocks`
+ * row. Its guidelines are stored per block in `guideline-block-*` rows.
  *
  * @since 7.1.0
  *
@@ -31,9 +33,9 @@
  *     @type array ...$0 {
  *         Data for a single scope.
  *
- *         @type string $title       Human-readable section title.
- *         @type string $description Human-readable section description.
- *         @type int    $order       Sort order on a Guidelines screen.
+ *         @type string $title       Human-readable scope title.
+ *         @type string $description Human-readable scope description.
+ *         @type int    $order       Sort order for the scope.
  *     }
  * }
  * @phpstan-return array<non-empty-string, array{title: string, description: string, order: int}>
@@ -64,6 +66,11 @@ function wp_guideline_scopes(): array {
 				'title'       => __( 'Images' ),
 				'description' => __( 'Outline your style, dimensions, formats, mood and aesthetic preferences.' ),
 				'order'       => 30,
+			),
+			'blocks'     => array(
+				'title'       => __( 'Blocks' ),
+				'description' => __( 'Create tailored guidelines for specific block types.' ),
+				'order'       => 40,
 			),
 			'additional' => array(
 				'title'       => __( 'Additional' ),

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -4,7 +4,7 @@
  *
  * @package WordPress
  * @subpackage Guidelines
- * @since 7.1.0
+ * @since 7.2.0
  */
 
 /**
@@ -17,7 +17,7 @@
  * The `blocks` scope is the exception: it has no single row. Its guidance lives in
  * per-block `guideline-block-*` rows so each block type can carry its own.
  *
- * @since 7.1.0
+ * @since 7.2.0
  *
  * @return array {
  *     Slug-keyed map of guideline scopes.
@@ -36,7 +36,7 @@ function wp_guideline_scopes(): array {
 	/**
 	 * Filters the guideline scopes available on this site.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param array $scopes Slug-keyed map of guideline scopes. See wp_guideline_scopes().
 	 * @phpstan-param array<non-empty-string, array{title: string, description: string, order: int}> $scopes
@@ -76,7 +76,7 @@ function wp_guideline_scopes(): array {
 /**
  * Returns the maximum length, in characters, of a guideline row's content.
  *
- * @since 7.1.0
+ * @since 7.2.0
  *
  * @return int Maximum number of characters allowed in guideline content.
  */
@@ -84,7 +84,7 @@ function wp_guideline_max_length(): int {
 	/**
 	 * Filters the maximum length, in characters, of a guideline row's content.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param int $max_length Maximum number of characters. Default 5000.
 	 */
@@ -99,7 +99,7 @@ function wp_guideline_max_length(): int {
  * scope. A null return means the slug is not a registered scope, so callers can
  * treat it as a recognized-guideline check.
  *
- * @since 7.1.0
+ * @since 7.2.0
  * @access private
  *
  * @param string $slug Post slug.
@@ -137,7 +137,7 @@ function wp_guideline_scope_from_slug( string $slug ): ?string {
  * the request omits it, applies the scope title (block rows keep their own), and
  * caps the content length.
  *
- * @since 7.1.0
+ * @since 7.2.0
  * @access private
  *
  * @param stdClass|WP_Error $prepared_post Prepared post, or WP_Error from a prior filter.

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -140,11 +140,16 @@ function wp_guideline_scope_from_slug( string $slug ): ?string {
  * @since 7.1.0
  * @access private
  *
- * @param stdClass        $prepared_post Prepared post object.
- * @param WP_REST_Request $request       Request object.
- * @return stdClass Prepared post object.
+ * @param stdClass|WP_Error $prepared_post Prepared post, or WP_Error from a prior filter.
+ * @param WP_REST_Request   $request       Request object.
+ * @return stdClass|WP_Error Prepared post object, or a WP_Error to reject the write.
  */
 function wp_guideline_prepare_rest_row( $prepared_post, $request ) {
+	// A prior filter may have rejected the write. Pass the error through untouched.
+	if ( is_wp_error( $prepared_post ) ) {
+		return $prepared_post;
+	}
+
 	// Resolve the target slug from the request, or from the existing row on an
 	// update that does not send one.
 	$slug = '';
@@ -169,11 +174,16 @@ function wp_guideline_prepare_rest_row( $prepared_post, $request ) {
 	$guideline_id   = is_array( $guideline_term ) ? (int) $guideline_term['term_id'] : 0;
 
 	if ( empty( $selected_terms ) ) {
-		// Assign the guideline type, creating the term on first use.
+		// Assign the guideline type, creating the term on first use. Reject the
+		// write if the term cannot be created.
 		if ( 0 === $guideline_id ) {
 			$created = wp_insert_term( 'guideline', 'wp_knowledge_type' );
 			if ( is_wp_error( $created ) ) {
-				return $prepared_post;
+				return new WP_Error(
+					'rest_cannot_create_guideline_type',
+					__( 'The guideline type could not be created.' ),
+					array( 'status' => 500 )
+				);
 			}
 			$guideline_id = (int) $created['term_id'];
 		}

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Guidelines API: Public functions for the guideline consumer layer.
+ *
+ * Guidelines are a consumer of the `wp_knowledge` storage primitive. Each
+ * guideline is a `wp_knowledge` row that carries the `guideline` type term and a
+ * `guideline-{scope}` slug. This file holds the scope registry, the slug
+ * helpers, the content length limit, the structural normalizers applied on every
+ * write path (the type reservation and the scope-title re-stamp), and the REST
+ * content sanitizer that shapes untrusted input at the request boundary.
+ *
+ * @package WordPress
+ * @subpackage Guidelines
+ * @since 7.1.0
+ */
+
+/**
+ * Retrieves the registered guideline scopes, keyed by slug.
+ *
+ * Scopes are the sections shown on a Guidelines management screen. Each scope is
+ * backed by at most one `guideline`-typed `wp_knowledge` row whose slug is
+ * `guideline-{scope}`. Plugins can register their own scopes via the
+ * {@see 'wp_guideline_scopes'} filter. The registry carries identity and
+ * presentation only. Rows are created on first save.
+ *
+ * @since 7.1.0
+ *
+ * @return array {
+ *     Slug-keyed map of guideline scopes.
+ *
+ *     @type array ...$0 {
+ *         Data for a single scope.
+ *
+ *         @type string $title       Human-readable section title.
+ *         @type string $description Human-readable section description.
+ *         @type int    $order       Sort order on a Guidelines screen.
+ *     }
+ * }
+ * @phpstan-return array<non-empty-string, array{title: string, description: string, order: int}>
+ */
+function wp_guideline_scopes(): array {
+	/**
+	 * Filters the guideline scopes available on this site.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array $scopes Slug-keyed map of guideline scopes. See wp_guideline_scopes().
+	 * @phpstan-param array<non-empty-string, array{title: string, description: string, order: int}> $scopes
+	 */
+	return apply_filters(
+		'wp_guideline_scopes',
+		array(
+			'site'       => array(
+				'title'       => __( 'Site' ),
+				'description' => __( "Describe your site's purpose, goals, and primary audience." ),
+				'order'       => 10,
+			),
+			'copy'       => array(
+				'title'       => __( 'Copy' ),
+				'description' => __( 'Set your writing standards for tone, voice, style, and formatting.' ),
+				'order'       => 20,
+			),
+			'images'     => array(
+				'title'       => __( 'Images' ),
+				'description' => __( 'Outline your style, dimensions, formats, mood and aesthetic preferences.' ),
+				'order'       => 30,
+			),
+			'additional' => array(
+				'title'       => __( 'Additional' ),
+				'description' => __( 'Add additional guidelines.' ),
+				'order'       => 50,
+			),
+		)
+	);
+}
+
+/**
+ * Returns the maximum length, in characters, of a guideline row's content.
+ *
+ * @since 7.1.0
+ *
+ * @return int Maximum number of characters allowed in guideline content.
+ */
+function wp_guideline_max_length(): int {
+	/**
+	 * Filters the maximum length, in characters, of a guideline row's content.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param int $max_length Maximum number of characters. Default 5000.
+	 */
+	return (int) apply_filters( 'wp_guideline_max_length', 5000 );
+}
+
+/**
+ * Resolves a registry scope key from a guideline row slug.
+ *
+ * Returns the scope key for `guideline-{scope}` slugs that match a registered
+ * scope. Returns null for block rows (`guideline-block-*`) and unknown scopes.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param string $slug Post slug.
+ * @return string|null Scope key, or null if the slug is not a registered scope.
+ */
+function wp_guideline_scope_from_slug( string $slug ): ?string {
+	if ( 0 !== strpos( $slug, 'guideline-' ) || 0 === strpos( $slug, 'guideline-block-' ) ) {
+		return null;
+	}
+
+	$scope  = substr( $slug, strlen( 'guideline-' ) );
+	$scopes = wp_guideline_scopes();
+
+	return isset( $scopes[ $scope ] ) ? $scope : null;
+}
+
+/**
+ * Reserves the `guideline` type term for guideline rows on save.
+ *
+ * Hooked to the `save_post_wp_knowledge` action at a priority before the
+ * knowledge primitive's default-term fallback (see
+ * wp_knowledge_ensure_default_type_term()). Rows whose slug begins with
+ * `guideline-` are forced onto the `guideline` type, so the prefix is reserved
+ * for guideline-typed rows. Once the term is assigned the primitive fallback
+ * sees a term and leaves the row alone.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param int $post_id Saved post ID.
+ */
+function wp_guideline_reserve_type_term( int $post_id ): void {
+	if ( wp_is_post_revision( $post_id ) ) {
+		return;
+	}
+
+	$post = get_post( $post_id );
+	if ( ! $post instanceof WP_Post || 0 !== strpos( $post->post_name, 'guideline-' ) ) {
+		return;
+	}
+
+	/*
+	 * Resolve to a term ID up front, creating the term on first use. The
+	 * site-locale label is applied by wp_knowledge_maybe_map_term_label() on the
+	 * wp_insert_term_data filter.
+	 */
+	$term = term_exists( 'guideline', 'wp_knowledge_type' );
+	if ( ! $term ) {
+		$term = wp_insert_term( 'guideline', 'wp_knowledge_type' );
+		if ( is_wp_error( $term ) ) {
+			return;
+		}
+	}
+
+	wp_set_object_terms( $post_id, (int) $term['term_id'], 'wp_knowledge_type' );
+}
+
+/**
+ * Re-stamps a guideline row's title from the scope registry on save.
+ *
+ * Hooked to the `wp_insert_post_data` filter so the invariant holds no matter
+ * how the row is written, not just over REST. For a `guideline-{scope}` slug that
+ * matches a registered scope, the title is set from wp_guideline_scopes() in the
+ * site locale, replacing any caller-provided title. Block rows
+ * (`guideline-block-*`) and unknown scopes are left untouched, so they keep their
+ * given title. The filter runs after wp_unique_post_slug(), so a suffixed
+ * duplicate slug no longer matches a scope and keeps its title.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param array $data    Slashed, sanitized post data about to be written.
+ * @param array $postarr Sanitized (and slashed) array of post data as passed.
+ * @return array Possibly modified post data.
+ */
+function wp_guideline_restamp_scope_title( $data, $postarr ) {
+	if ( ! isset( $data['post_type'] ) || 'wp_knowledge' !== $data['post_type'] ) {
+		return $data;
+	}
+
+	$scope = wp_guideline_scope_from_slug( isset( $data['post_name'] ) ? (string) $data['post_name'] : '' );
+	if ( null === $scope ) {
+		return $data;
+	}
+
+	$switched_locale = switch_to_locale( get_locale() );
+	$scopes          = wp_guideline_scopes();
+	if ( $switched_locale ) {
+		restore_previous_locale();
+	}
+
+	if ( isset( $scopes[ $scope ]['title'] ) ) {
+		// $data is slashed at this filter, so slash the registry title to match.
+		$data['post_title'] = wp_slash( $scopes[ $scope ]['title'] );
+	}
+
+	return $data;
+}
+
+/**
+ * Sanitizes guideline content on the REST insert path.
+ *
+ * Hooked to the `rest_pre_insert_wp_knowledge` filter. For rows whose slug begins
+ * with `guideline-`, the content is reduced to plain text and capped at
+ * wp_guideline_max_length(). This shapes untrusted client input, so it lives at
+ * the REST boundary. The type term and the scope title are structural invariants
+ * applied on every write path (see wp_guideline_reserve_type_term() and
+ * wp_guideline_restamp_scope_title()).
+ *
+ * Slug uniqueness is left to WordPress. The first save of a scope keeps its exact
+ * slug, later saves reuse that row by ID, and any other row with the same desired
+ * slug is suffixed by wp_unique_post_slug(). A Guidelines screen reads the
+ * published row by its exact slug, so suffixed rows are ignored.
+ *
+ * @since 7.1.0
+ * @access private
+ *
+ * @param stdClass        $prepared_post Prepared post object.
+ * @param WP_REST_Request $request       Request object.
+ * @return stdClass Prepared post object.
+ */
+function wp_guideline_sanitize_rest_content( $prepared_post, $request ) {
+	if ( ! isset( $prepared_post->post_content ) ) {
+		return $prepared_post;
+	}
+
+	$slug = '';
+	if ( ! empty( $prepared_post->post_name ) ) {
+		$slug = $prepared_post->post_name;
+	} elseif ( ! empty( $prepared_post->ID ) ) {
+		$existing = get_post( $prepared_post->ID );
+		if ( $existing instanceof WP_Post ) {
+			$slug = $existing->post_name;
+		}
+	}
+
+	if ( 0 !== strpos( (string) $slug, 'guideline-' ) ) {
+		return $prepared_post;
+	}
+
+	$content = sanitize_textarea_field( $prepared_post->post_content );
+	$max     = wp_guideline_max_length();
+	if ( mb_strlen( $content, 'UTF-8' ) > $max ) {
+		$content = mb_substr( $content, 0, $max, 'UTF-8' );
+	}
+	$prepared_post->post_content = $content;
+
+	return $prepared_post;
+}

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -1,13 +1,6 @@
 <?php
 /**
- * Guidelines API: Public functions for the guideline consumer layer.
- *
- * Guidelines are a consumer of the `wp_knowledge` storage primitive. Each
- * guideline is a `wp_knowledge` row that carries the `guideline` type term and a
- * `guideline-{scope}` slug. This file holds the scope registry, the scope
- * resolver, the content length limit, and the single REST insert callback that
- * shapes a guideline row: for a recognized scope slug it sets the guideline type,
- * sets the title, and caps the content, all in one place.
+ * Guidelines API: the guideline consumer layer over the wp_knowledge primitive.
  *
  * @package WordPress
  * @subpackage Guidelines
@@ -17,13 +10,12 @@
 /**
  * Retrieves the registered guideline scopes, keyed by slug.
  *
- * A scope groups guideline content under a stable key. Each scope is backed by
- * at most one `guideline`-typed `wp_knowledge` row whose slug is
- * `guideline-{scope}`. Rows are created on first save. Plugins can register or
- * remove scopes via the {@see 'wp_guideline_scopes'} filter.
+ * Each scope is a section of guidance backed by a `guideline`-typed `wp_knowledge`
+ * row with a `guideline-{scope}` slug. Filter {@see 'wp_guideline_scopes'} to add
+ * or remove scopes for a site.
  *
- * The `blocks` scope is the one exception. It has no single `guideline-blocks`
- * row. Its guidelines are stored per block in `guideline-block-*` rows.
+ * The `blocks` scope is the exception: it has no single row. Its guidance lives in
+ * per-block `guideline-block-*` rows so each block type can carry its own.
  *
  * @since 7.1.0
  *
@@ -100,12 +92,12 @@ function wp_guideline_max_length(): int {
 }
 
 /**
- * Resolves a registry scope key from a guideline row slug.
+ * Maps a guideline row slug to the scope that owns it.
  *
- * Returns the scope key for a `guideline-{scope}` slug that matches a registered
- * scope. Per-block rows (`guideline-block-{block}`) resolve to the `blocks` scope
- * when it is registered. Returns null for unknown scopes, and for block rows when
- * the `blocks` scope is not registered.
+ * Use this to tell whether a `wp_knowledge` row is a guideline and, if so, which
+ * scope it belongs to. Per-block rows (`guideline-block-*`) belong to the `blocks`
+ * scope. A null return means the slug is not a registered scope, so callers can
+ * treat it as a recognized-guideline check.
  *
  * @since 7.1.0
  * @access private
@@ -131,22 +123,19 @@ function wp_guideline_scope_from_slug( string $slug ): ?string {
 }
 
 /**
- * Shapes a guideline row on the REST insert path.
+ * Normalizes a guideline row as it is written over REST.
  *
- * Hooked to the `rest_pre_insert_wp_knowledge` filter. This is the single place
- * that shapes a guideline row, so every guideline-specific change is applied
- * uniformly and nothing else needs to. Two gates decide whether the row is shaped:
- * the slug must map to a registered scope (see wp_guideline_scope_from_slug(),
- * which resolves both `guideline-{scope}` and per-block `guideline-block-*` rows),
- * and, if the request selects any `wp_knowledge_type` terms, the `guideline` term
- * must be among them. A row that fails either gate is left untouched, as is any
- * row written outside REST. When both gates pass:
+ * Hooked to `rest_pre_insert_wp_knowledge`. Guideline rows are only created and
+ * edited over REST, so this one callback owns every guideline-specific change.
+ * Keeping them in one place makes it clear they apply to guideline rows and
+ * nothing else.
  *
- * - The `guideline` type is set when the request selects no term. The standard
- *   REST term handling assigns it after insert.
- * - A single-row scope takes its registry title in the site locale. The multi-row
- *   `blocks` scope keeps each row's block-name title.
- * - Content is reduced to plain text and capped at wp_guideline_max_length().
+ * A row counts as a guideline only when its slug maps to a registered scope and it
+ * is typed (or left for the server to type) as `guideline`. A request that types
+ * the row as something else is left alone, so a guideline slug cannot be
+ * repurposed. For a guideline row the callback fills in the `guideline` type when
+ * the request omits it, applies the scope title (block rows keep their own), and
+ * caps the content length.
  *
  * @since 7.1.0
  * @access private
@@ -173,10 +162,8 @@ function wp_guideline_prepare_rest_row( $prepared_post, $request ) {
 		return $prepared_post;
 	}
 
-	// This is a guideline row when the request selects no type, in which case the
-	// server assigns it the guideline type, or when the type it selects includes
-	// the guideline term. Any other selection means the row is not a guideline, so
-	// it is left untouched.
+	// Assign the guideline type when the request selects none. If it selects a
+	// type, it must include the guideline term, or the row is not a guideline.
 	$selected_terms = $request['wp_knowledge_type'];
 	$guideline_term = term_exists( 'guideline', 'wp_knowledge_type' );
 	$guideline_id   = is_array( $guideline_term ) ? (int) $guideline_term['term_id'] : 0;

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -4,10 +4,10 @@
  *
  * Guidelines are a consumer of the `wp_knowledge` storage primitive. Each
  * guideline is a `wp_knowledge` row that carries the `guideline` type term and a
- * `guideline-{scope}` slug. This file holds the scope registry, the slug
- * helpers, the content length limit, the structural normalizers applied on every
- * write path (the type reservation and the scope-title re-stamp), and the REST
- * content sanitizer that shapes untrusted input at the request boundary.
+ * `guideline-{scope}` slug. This file holds the scope registry, the scope
+ * resolver, the content length limit, and the single REST insert callback that
+ * shapes a guideline row: for a recognized scope slug it sets the guideline type,
+ * sets the title, and caps the content, all in one place.
  *
  * @package WordPress
  * @subpackage Guidelines
@@ -102,8 +102,10 @@ function wp_guideline_max_length(): int {
 /**
  * Resolves a registry scope key from a guideline row slug.
  *
- * Returns the scope key for `guideline-{scope}` slugs that match a registered
- * scope. Returns null for block rows (`guideline-block-*`) and unknown scopes.
+ * Returns the scope key for a `guideline-{scope}` slug that matches a registered
+ * scope. Per-block rows (`guideline-block-{block}`) resolve to the `blocks` scope
+ * when it is registered. Returns null for unknown scopes, and for block rows when
+ * the `blocks` scope is not registered.
  *
  * @since 7.1.0
  * @access private
@@ -112,113 +114,39 @@ function wp_guideline_max_length(): int {
  * @return string|null Scope key, or null if the slug is not a registered scope.
  */
 function wp_guideline_scope_from_slug( string $slug ): ?string {
-	if ( 0 !== strpos( $slug, 'guideline-' ) || 0 === strpos( $slug, 'guideline-block-' ) ) {
+	if ( ! str_starts_with( $slug, 'guideline-' ) ) {
 		return null;
 	}
 
-	$scope  = substr( $slug, strlen( 'guideline-' ) );
 	$scopes = wp_guideline_scopes();
+
+	// Per-block rows belong to the blocks scope when it is registered.
+	if ( str_starts_with( $slug, 'guideline-block-' ) && strlen( $slug ) > strlen( 'guideline-block-' ) ) {
+		return isset( $scopes['blocks'] ) ? 'blocks' : null;
+	}
+
+	$scope = substr( $slug, strlen( 'guideline-' ) );
 
 	return isset( $scopes[ $scope ] ) ? $scope : null;
 }
 
 /**
- * Reserves the `guideline` type term for guideline rows on save.
+ * Shapes a guideline row on the REST insert path.
  *
- * Hooked to the `save_post_wp_knowledge` action at a priority before the
- * knowledge primitive's default-term fallback (see
- * wp_knowledge_ensure_default_type_term()). Rows whose slug begins with
- * `guideline-` are forced onto the `guideline` type, so the prefix is reserved
- * for guideline-typed rows. Once the term is assigned the primitive fallback
- * sees a term and leaves the row alone.
+ * Hooked to the `rest_pre_insert_wp_knowledge` filter. This is the single place
+ * that shapes a guideline row, so every guideline-specific change is applied
+ * uniformly and nothing else needs to. Two gates decide whether the row is shaped:
+ * the slug must map to a registered scope (see wp_guideline_scope_from_slug(),
+ * which resolves both `guideline-{scope}` and per-block `guideline-block-*` rows),
+ * and, if the request selects any `wp_knowledge_type` terms, the `guideline` term
+ * must be among them. A row that fails either gate is left untouched, as is any
+ * row written outside REST. When both gates pass:
  *
- * @since 7.1.0
- * @access private
- *
- * @param int $post_id Saved post ID.
- */
-function wp_guideline_reserve_type_term( int $post_id ): void {
-	if ( wp_is_post_revision( $post_id ) ) {
-		return;
-	}
-
-	$post = get_post( $post_id );
-	if ( ! $post instanceof WP_Post || 0 !== strpos( $post->post_name, 'guideline-' ) ) {
-		return;
-	}
-
-	/*
-	 * Resolve to a term ID up front, creating the term on first use. The
-	 * site-locale label is applied by wp_knowledge_maybe_map_term_label() on the
-	 * wp_insert_term_data filter.
-	 */
-	$term = term_exists( 'guideline', 'wp_knowledge_type' );
-	if ( ! $term ) {
-		$term = wp_insert_term( 'guideline', 'wp_knowledge_type' );
-		if ( is_wp_error( $term ) ) {
-			return;
-		}
-	}
-
-	wp_set_object_terms( $post_id, (int) $term['term_id'], 'wp_knowledge_type' );
-}
-
-/**
- * Re-stamps a guideline row's title from the scope registry on save.
- *
- * Hooked to the `wp_insert_post_data` filter so the invariant holds no matter
- * how the row is written, not just over REST. For a `guideline-{scope}` slug that
- * matches a registered scope, the title is set from wp_guideline_scopes() in the
- * site locale, replacing any caller-provided title. Block rows
- * (`guideline-block-*`) and unknown scopes are left untouched, so they keep their
- * given title. The filter runs after wp_unique_post_slug(), so a suffixed
- * duplicate slug no longer matches a scope and keeps its title.
- *
- * @since 7.1.0
- * @access private
- *
- * @param array $data    Slashed, sanitized post data about to be written.
- * @param array $postarr Sanitized (and slashed) array of post data as passed.
- * @return array Possibly modified post data.
- */
-function wp_guideline_restamp_scope_title( $data, $postarr ) {
-	if ( ! isset( $data['post_type'] ) || 'wp_knowledge' !== $data['post_type'] ) {
-		return $data;
-	}
-
-	$scope = wp_guideline_scope_from_slug( isset( $data['post_name'] ) ? (string) $data['post_name'] : '' );
-	if ( null === $scope ) {
-		return $data;
-	}
-
-	$switched_locale = switch_to_locale( get_locale() );
-	$scopes          = wp_guideline_scopes();
-	if ( $switched_locale ) {
-		restore_previous_locale();
-	}
-
-	if ( isset( $scopes[ $scope ]['title'] ) ) {
-		// $data is slashed at this filter, so slash the registry title to match.
-		$data['post_title'] = wp_slash( $scopes[ $scope ]['title'] );
-	}
-
-	return $data;
-}
-
-/**
- * Sanitizes guideline content on the REST insert path.
- *
- * Hooked to the `rest_pre_insert_wp_knowledge` filter. For rows whose slug begins
- * with `guideline-`, the content is reduced to plain text and capped at
- * wp_guideline_max_length(). This shapes untrusted client input, so it lives at
- * the REST boundary. The type term and the scope title are structural invariants
- * applied on every write path (see wp_guideline_reserve_type_term() and
- * wp_guideline_restamp_scope_title()).
- *
- * Slug uniqueness is left to WordPress. The first save of a scope keeps its exact
- * slug, later saves reuse that row by ID, and any other row with the same desired
- * slug is suffixed by wp_unique_post_slug(). A Guidelines screen reads the
- * published row by its exact slug, so suffixed rows are ignored.
+ * - The `guideline` type is set when the request selects no term. The standard
+ *   REST term handling assigns it after insert.
+ * - A single-row scope takes its registry title in the site locale. The multi-row
+ *   `blocks` scope keeps each row's block-name title.
+ * - Content is reduced to plain text and capped at wp_guideline_max_length().
  *
  * @since 7.1.0
  * @access private
@@ -227,31 +155,69 @@ function wp_guideline_restamp_scope_title( $data, $postarr ) {
  * @param WP_REST_Request $request       Request object.
  * @return stdClass Prepared post object.
  */
-function wp_guideline_sanitize_rest_content( $prepared_post, $request ) {
-	if ( ! isset( $prepared_post->post_content ) ) {
-		return $prepared_post;
-	}
-
+function wp_guideline_prepare_rest_row( $prepared_post, $request ) {
+	// Resolve the target slug from the request, or from the existing row on an
+	// update that does not send one.
 	$slug = '';
 	if ( ! empty( $prepared_post->post_name ) ) {
-		$slug = $prepared_post->post_name;
+		$slug = (string) $prepared_post->post_name;
 	} elseif ( ! empty( $prepared_post->ID ) ) {
 		$existing = get_post( $prepared_post->ID );
 		if ( $existing instanceof WP_Post ) {
-			$slug = $existing->post_name;
+			$slug = (string) $existing->post_name;
 		}
 	}
 
-	if ( 0 !== strpos( (string) $slug, 'guideline-' ) ) {
+	$scope = wp_guideline_scope_from_slug( $slug );
+	if ( null === $scope ) {
 		return $prepared_post;
 	}
 
-	$content = sanitize_textarea_field( $prepared_post->post_content );
-	$max     = wp_guideline_max_length();
-	if ( mb_strlen( $content, 'UTF-8' ) > $max ) {
-		$content = mb_substr( $content, 0, $max, 'UTF-8' );
+	// This is a guideline row when the request selects no type, in which case the
+	// server assigns it the guideline type, or when the type it selects includes
+	// the guideline term. Any other selection means the row is not a guideline, so
+	// it is left untouched.
+	$selected_terms = $request['wp_knowledge_type'];
+	$guideline_term = term_exists( 'guideline', 'wp_knowledge_type' );
+	$guideline_id   = is_array( $guideline_term ) ? (int) $guideline_term['term_id'] : 0;
+
+	if ( empty( $selected_terms ) ) {
+		// Assign the guideline type, creating the term on first use.
+		if ( 0 === $guideline_id ) {
+			$created = wp_insert_term( 'guideline', 'wp_knowledge_type' );
+			if ( is_wp_error( $created ) ) {
+				return $prepared_post;
+			}
+			$guideline_id = (int) $created['term_id'];
+		}
+		$request['wp_knowledge_type'] = array( $guideline_id );
+	} elseif ( 0 === $guideline_id || ! in_array( $guideline_id, array_map( 'intval', (array) $selected_terms ), true ) ) {
+		return $prepared_post;
 	}
-	$prepared_post->post_content = $content;
+
+	// A single-row scope takes its registry title in the site locale. The blocks
+	// scope is multi-row, so its per-block rows keep their block-name title.
+	if ( 'blocks' !== $scope ) {
+		$switched_locale = switch_to_locale( get_locale() );
+		$scopes          = wp_guideline_scopes();
+		if ( $switched_locale ) {
+			restore_previous_locale();
+		}
+
+		if ( isset( $scopes[ $scope ]['title'] ) ) {
+			$prepared_post->post_title = $scopes[ $scope ]['title'];
+		}
+	}
+
+	// Reduce content to plain text and cap its length.
+	if ( isset( $prepared_post->post_content ) ) {
+		$content = sanitize_textarea_field( $prepared_post->post_content );
+		$max     = wp_guideline_max_length();
+		if ( mb_strlen( $content, 'UTF-8' ) > $max ) {
+			$content = mb_substr( $content, 0, $max, 'UTF-8' );
+		}
+		$prepared_post->post_content = $content;
+	}
 
 	return $prepared_post;
 }

--- a/src/wp-includes/guidelines.php
+++ b/src/wp-includes/guidelines.php
@@ -95,9 +95,11 @@ function wp_guideline_max_length(): int {
  * Maps a guideline row slug to the scope that owns it.
  *
  * Use this to tell whether a `wp_knowledge` row is a guideline and, if so, which
- * scope it belongs to. Per-block rows (`guideline-block-*`) belong to the `blocks`
- * scope. A null return means the slug is not a registered scope, so callers can
- * treat it as a recognized-guideline check.
+ * scope it belongs to. A registered scope key always wins, so a scope keyed like
+ * `block-foo` resolves to itself rather than to the blocks scope. Any other
+ * per-block row (`guideline-block-*`) belongs to the `blocks` scope. A null return
+ * means the slug is not a registered scope, so callers can treat it as a
+ * recognized-guideline check.
  *
  * @since 7.2.0
  * @access private
@@ -111,15 +113,23 @@ function wp_guideline_scope_from_slug( string $slug ): ?string {
 	}
 
 	$scopes = wp_guideline_scopes();
+	$scope  = substr( $slug, strlen( 'guideline-' ) );
 
-	// Per-block rows belong to the blocks scope when it is registered.
+	// A slug that matches a registered scope key is that scope. Checking this
+	// first lets a scope keyed like `block-foo` win over the per-block namespace
+	// below, instead of being swallowed by the blocks scope.
+	if ( isset( $scopes[ $scope ] ) ) {
+		return $scope;
+	}
+
+	// Otherwise a `guideline-block-<name>` row is a per-block row that belongs to
+	// the blocks scope while it is registered. A real block name never equals a
+	// registered scope key, so the check above stays safe.
 	if ( str_starts_with( $slug, 'guideline-block-' ) && strlen( $slug ) > strlen( 'guideline-block-' ) ) {
 		return isset( $scopes['blocks'] ) ? 'blocks' : null;
 	}
 
-	$scope = substr( $slug, strlen( 'guideline-' ) );
-
-	return isset( $scopes[ $scope ] ) ? $scope : null;
+	return null;
 }
 
 /**

--- a/src/wp-includes/rest-api.php
+++ b/src/wp-includes/rest-api.php
@@ -432,6 +432,10 @@ function create_initial_rest_routes() {
 	// View Config.
 	$view_config_controller = new WP_REST_View_Config_Controller();
 	$view_config_controller->register_routes();
+
+	// Guideline Scopes.
+	$guideline_scopes_controller = new WP_REST_Guideline_Scopes_Controller();
+	$guideline_scopes_controller->register_routes();
 }
 
 /**

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-guideline-scopes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-guideline-scopes-controller.php
@@ -4,7 +4,7 @@
  *
  * @package WordPress
  * @subpackage REST_API
- * @since 7.1.0
+ * @since 7.2.0
  */
 
 /**
@@ -15,7 +15,7 @@
  * semantics. A Guidelines screen preloads it, then reads and writes the scope
  * rows through the standard `/wp/v2/knowledge` collection.
  *
- * @since 7.1.0
+ * @since 7.2.0
  *
  * @see WP_REST_Controller
  */
@@ -24,7 +24,7 @@ class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
 	/**
 	 * Constructor.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 */
 	public function __construct() {
 		$this->namespace = 'wp/v2';
@@ -34,7 +34,7 @@ class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
 	/**
 	 * Registers the routes for guideline scopes.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @see register_rest_route()
 	 */
@@ -58,7 +58,7 @@ class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
 	 *
 	 * Gated on the knowledge read capability, matching the data routes.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
@@ -80,7 +80,7 @@ class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
 	 *
 	 * Labels are resolved at request time, in the request locale.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return WP_REST_Response Response object.
@@ -99,7 +99,7 @@ class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
 	/**
 	 * Prepares a single guideline scope for response.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @param array           $item    Scope data with a `slug` key.
 	 * @param WP_REST_Request $request Request object.
@@ -132,7 +132,7 @@ class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
 	/**
 	 * Retrieves the guideline scope schema, conforming to JSON Schema.
 	 *
-	 * @since 7.1.0
+	 * @since 7.2.0
 	 *
 	 * @return array Item schema data.
 	 */

--- a/src/wp-includes/rest-api/endpoints/class-wp-rest-guideline-scopes-controller.php
+++ b/src/wp-includes/rest-api/endpoints/class-wp-rest-guideline-scopes-controller.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * REST API: WP_REST_Guideline_Scopes_Controller class
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ * @since 7.1.0
+ */
+
+/**
+ * Core controller used to read the guideline scopes registry via the REST API.
+ *
+ * This is a read-only registry endpoint beside the knowledge data routes, the
+ * same species as `/wp/v2/statuses`. It has no write paths and carries no data
+ * semantics. A Guidelines screen preloads it, then reads and writes the scope
+ * rows through the standard `/wp/v2/knowledge` collection.
+ *
+ * @since 7.1.0
+ *
+ * @see WP_REST_Controller
+ */
+class WP_REST_Guideline_Scopes_Controller extends WP_REST_Controller {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since 7.1.0
+	 */
+	public function __construct() {
+		$this->namespace = 'wp/v2';
+		$this->rest_base = 'knowledge/guideline-scopes';
+	}
+
+	/**
+	 * Registers the routes for guideline scopes.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @see register_rest_route()
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Checks whether the current user can read guideline scopes.
+	 *
+	 * Gated on the knowledge read capability, matching the data routes.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request has read access, WP_Error object otherwise.
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'read_knowledge_items' ) ) {
+			return new WP_Error(
+				'rest_cannot_read',
+				__( 'Sorry, you are not allowed to view guideline scopes.' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Retrieves all registered guideline scopes.
+	 *
+	 * Labels are resolved at request time, in the request locale.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function get_items( $request ) {
+		$data = array();
+
+		foreach ( wp_guideline_scopes() as $slug => $scope ) {
+			$item   = $this->prepare_item_for_response( array_merge( array( 'slug' => $slug ), $scope ), $request );
+			$data[] = $this->prepare_response_for_collection( $item );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepares a single guideline scope for response.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @param array           $item    Scope data with a `slug` key.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response Response object.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$fields = $this->get_fields_for_response( $request );
+		$data   = array();
+
+		if ( rest_is_field_included( 'slug', $fields ) ) {
+			$data['slug'] = $item['slug'];
+		}
+		if ( rest_is_field_included( 'title', $fields ) ) {
+			$data['title'] = isset( $item['title'] ) ? $item['title'] : '';
+		}
+		if ( rest_is_field_included( 'description', $fields ) ) {
+			$data['description'] = isset( $item['description'] ) ? $item['description'] : '';
+		}
+		if ( rest_is_field_included( 'order', $fields ) ) {
+			$data['order'] = isset( $item['order'] ) ? (int) $item['order'] : 0;
+		}
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Retrieves the guideline scope schema, conforming to JSON Schema.
+	 *
+	 * @since 7.1.0
+	 *
+	 * @return array Item schema data.
+	 */
+	public function get_item_schema() {
+		if ( $this->schema ) {
+			return $this->add_additional_fields_schema( $this->schema );
+		}
+
+		$this->schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'guideline-scope',
+			'type'       => 'object',
+			'properties' => array(
+				'slug'        => array(
+					'description' => __( 'An alphanumeric identifier for the scope.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'title'       => array(
+					'description' => __( 'The title for the scope.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'A human-readable description of the scope.' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+				'order'       => array(
+					'description' => __( 'The sort order of the scope on a Guidelines screen.' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit', 'embed' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $this->schema );
+	}
+}

--- a/src/wp-settings.php
+++ b/src/wp-settings.php
@@ -257,6 +257,7 @@ require ABSPATH . WPINC . '/class-wp-term.php';
 require ABSPATH . WPINC . '/class-wp-term-query.php';
 require ABSPATH . WPINC . '/class-wp-tax-query.php';
 require ABSPATH . WPINC . '/knowledge.php';
+require ABSPATH . WPINC . '/guidelines.php';
 require ABSPATH . WPINC . '/update.php';
 require ABSPATH . WPINC . '/canonical.php';
 require ABSPATH . WPINC . '/shortcodes.php';
@@ -361,6 +362,7 @@ require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-font-families-contr
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-font-faces-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-font-collections-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-knowledge-controller.php';
+require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-guideline-scopes-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-icons-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-view-config-controller.php';
 require ABSPATH . WPINC . '/rest-api/endpoints/class-wp-rest-abilities-v1-categories-controller.php';

--- a/tests/phpunit/tests/guidelines/reservation.php
+++ b/tests/phpunit/tests/guidelines/reservation.php
@@ -310,4 +310,34 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 		$this->assertStringNotContainsString( '<script', $content );
 		$this->assertLessThanOrEqual( 5000, mb_strlen( $content, 'UTF-8' ) );
 	}
+
+	/**
+	 * When the guideline term cannot be created, the write is rejected with the
+	 * error instead of saving an untyped row.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_prepare_rest_row
+	 */
+	public function test_rejects_write_when_guideline_term_cannot_be_created() {
+		wp_set_current_user( self::$admin_id );
+
+		// Force term creation to fail so the guideline term cannot be created.
+		add_filter(
+			'pre_insert_term',
+			static function () {
+				return new WP_Error( 'test_term_blocked', 'No terms today.' );
+			}
+		);
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-copy',
+				'content' => 'Use active voice.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 500, $response->get_status() );
+		$this->assertSame( 'rest_cannot_create_guideline_type', $response->get_data()['code'] );
+	}
 }

--- a/tests/phpunit/tests/guidelines/reservation.php
+++ b/tests/phpunit/tests/guidelines/reservation.php
@@ -1,0 +1,217 @@
+<?php
+/**
+ * Tests for the guideline-row reservation and REST insert guard.
+ *
+ * Covers the forced `guideline` type, slug uniqueness handling, scope-title
+ * re-stamping, and content sanitization on the REST insert path.
+ *
+ * @package WordPress
+ * @subpackage Guidelines
+ *
+ * @group guidelines
+ * @group restapi
+ */
+class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * Creates a knowledge row via REST.
+	 *
+	 * @param array $body Request body params.
+	 * @return WP_REST_Response Response object.
+	 */
+	private function create_row( array $body ): WP_REST_Response {
+		$request = new WP_REST_Request( 'POST', '/wp/v2/knowledge' );
+		$request->set_body_params( $body );
+		return rest_get_server()->dispatch( $request );
+	}
+
+	/**
+	 * A row created with a `guideline-` slug is forced onto the `guideline`
+	 * type and, with no collision, keeps its exact slug.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_reserve_type_term
+	 */
+	public function test_prefixed_slug_forces_guideline_term_and_keeps_slug() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-copy',
+				'content' => 'Use active voice.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$id = $response->get_data()['id'];
+
+		$this->assertSame( 'guideline-copy', get_post( $id )->post_name );
+
+		$terms = wp_get_object_terms( $id, 'wp_knowledge_type', array( 'fields' => 'slugs' ) );
+		$this->assertSame( array( 'guideline' ), $terms );
+	}
+
+	/**
+	 * A second create with an already-used `guideline-` slug is not rejected.
+	 * WordPress suffixes the slug, and the published row keeps the exact slug.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_restamp_scope_title
+	 */
+	public function test_duplicate_slug_is_suffixed_not_rejected() {
+		wp_set_current_user( self::$admin_id );
+
+		$first = $this->create_row(
+			array(
+				'slug'    => 'guideline-site',
+				'content' => 'First.',
+				'status'  => 'publish',
+			)
+		);
+		$this->assertSame( 201, $first->get_status() );
+		$this->assertSame( 'guideline-site', get_post( $first->get_data()['id'] )->post_name );
+
+		$second = $this->create_row(
+			array(
+				'slug'    => 'guideline-site',
+				'content' => 'Second.',
+				'status'  => 'publish',
+			)
+		);
+		$this->assertSame( 201, $second->get_status() );
+		$this->assertSame( 'guideline-site-2', get_post( $second->get_data()['id'] )->post_name );
+	}
+
+	/**
+	 * A content-only update of an existing row succeeds. The slug and title are
+	 * left untouched.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_sanitize_rest_content
+	 */
+	public function test_content_only_update_succeeds() {
+		wp_set_current_user( self::$admin_id );
+
+		$created = $this->create_row(
+			array(
+				'slug'    => 'guideline-copy',
+				'content' => 'First.',
+				'status'  => 'publish',
+			)
+		);
+		$this->assertSame( 201, $created->get_status() );
+		$id = $created->get_data()['id'];
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/knowledge/' . $id );
+		$request->set_body_params( array( 'content' => 'Second.' ) );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 'Second.', get_post( $id )->post_content );
+	}
+
+	/**
+	 * Registry scope titles are re-stamped from wp_guideline_scopes(), ignoring
+	 * any client-provided title.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_restamp_scope_title
+	 */
+	public function test_scope_title_restamped_from_registry() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-images',
+				'title'   => 'Bogus client title',
+				'content' => 'Square images only.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'Images', get_post( $response->get_data()['id'] )->post_title );
+	}
+
+	/**
+	 * Block rows keep the client-provided canonical block name as the title.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_restamp_scope_title
+	 */
+	public function test_block_row_keeps_canonical_title() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-block-core-paragraph',
+				'title'   => 'core/paragraph',
+				'content' => 'Keep paragraphs short.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'core/paragraph', get_post( $response->get_data()['id'] )->post_title );
+	}
+
+	/**
+	 * Content is sanitized to plain text and capped at the guideline length.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_sanitize_rest_content
+	 */
+	public function test_content_sanitized_and_capped() {
+		wp_set_current_user( self::$admin_id );
+
+		$long = str_repeat( 'a', 6000 );
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-additional',
+				'content' => '<script>alert(1)</script>' . $long,
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$content = get_post( $response->get_data()['id'] )->post_content;
+
+		$this->assertStringNotContainsString( '<script', $content );
+		$this->assertLessThanOrEqual( 5000, mb_strlen( $content, 'UTF-8' ) );
+	}
+
+	/**
+	 * The scope title is re-stamped even when the row is created outside REST,
+	 * because the invariant is enforced on the generic save path.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_restamp_scope_title
+	 */
+	public function test_scope_title_restamped_on_direct_insert() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_knowledge',
+				'post_status'  => 'private',
+				'post_name'    => 'guideline-copy',
+				'post_title'   => 'Bogus title',
+				'post_content' => 'Be concise.',
+			)
+		);
+
+		$this->assertGreaterThan( 0, $post_id );
+		$this->assertSame( 'Copy', get_post( $post_id )->post_title );
+	}
+}

--- a/tests/phpunit/tests/guidelines/reservation.php
+++ b/tests/phpunit/tests/guidelines/reservation.php
@@ -1,9 +1,10 @@
 <?php
 /**
- * Tests for the guideline-row reservation and REST insert guard.
+ * Tests for guideline-row shaping on write.
  *
- * Covers the forced `guideline` type, slug uniqueness handling, scope-title
- * re-stamping, and content sanitization on the REST insert path.
+ * Covers the single REST insert callback that, for a recognized scope slug, forces
+ * the guideline type, sets the title, and caps the content. Also covers slug
+ * uniqueness handling.
  *
  * @package WordPress
  * @subpackage Guidelines
@@ -37,13 +38,13 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * A row created with a `guideline-` slug is forced onto the `guideline`
-	 * type and, with no collision, keeps its exact slug.
+	 * A REST write with a recognized scope slug gets the guideline type and, with
+	 * no collision, keeps its exact slug.
 	 *
 	 * @ticket 65476
-	 * @covers ::wp_guideline_reserve_type_term
+	 * @covers ::wp_guideline_prepare_rest_row
 	 */
-	public function test_prefixed_slug_forces_guideline_term_and_keeps_slug() {
+	public function test_sets_guideline_type_for_scope_slug() {
 		wp_set_current_user( self::$admin_id );
 
 		$response = $this->create_row(
@@ -64,11 +65,128 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 	}
 
 	/**
+	 * A REST write whose slug is not a registered scope is left untouched.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_prepare_rest_row
+	 */
+	public function test_does_not_set_type_for_unrecognized_slug() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-nope',
+				'content' => 'Text.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$terms = wp_get_object_terms( $response->get_data()['id'], 'wp_knowledge_type', array( 'fields' => 'slugs' ) );
+		$this->assertNotContains( 'guideline', $terms );
+	}
+
+	/**
+	 * A REST write with a per-block slug gets the guideline type when the blocks
+	 * scope is registered.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_prepare_rest_row
+	 */
+	public function test_sets_guideline_type_for_block_slug() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = $this->create_row(
+			array(
+				'slug'    => 'guideline-block-core-paragraph',
+				'title'   => 'core/paragraph',
+				'content' => 'Keep paragraphs short.',
+				'status'  => 'publish',
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+
+		$terms = wp_get_object_terms( $response->get_data()['id'], 'wp_knowledge_type', array( 'fields' => 'slugs' ) );
+		$this->assertSame( array( 'guideline' ), $terms );
+	}
+
+	/**
+	 * A recognized slug whose selected type does not include the guideline term is
+	 * not a guideline row. It is left untouched: the type is kept and the scope
+	 * title is not stamped.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_prepare_rest_row
+	 */
+	public function test_leaves_row_when_selected_type_excludes_guideline() {
+		wp_set_current_user( self::$admin_id );
+
+		$note = term_exists( 'note', 'wp_knowledge_type' );
+		if ( ! $note ) {
+			$note = wp_insert_term( 'note', 'wp_knowledge_type' );
+		}
+		$note_id = (int) $note['term_id'];
+
+		$response = $this->create_row(
+			array(
+				'slug'              => 'guideline-site',
+				'title'             => 'My title',
+				'content'           => 'Text.',
+				'status'            => 'publish',
+				'wp_knowledge_type' => array( $note_id ),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$post = get_post( $response->get_data()['id'] );
+
+		$terms = wp_get_object_terms( $post->ID, 'wp_knowledge_type', array( 'fields' => 'slugs' ) );
+		$this->assertSame( array( 'note' ), $terms );
+		$this->assertSame( 'My title', $post->post_title );
+	}
+
+	/**
+	 * A recognized slug whose selected type includes the guideline term is a
+	 * guideline row, so it is shaped: the scope title is stamped.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_prepare_rest_row
+	 */
+	public function test_shapes_row_when_selected_type_includes_guideline() {
+		wp_set_current_user( self::$admin_id );
+
+		// A first guideline write creates the guideline term.
+		$this->create_row(
+			array(
+				'slug'    => 'guideline-copy',
+				'content' => 'Seed.',
+				'status'  => 'publish',
+			)
+		);
+		$guideline_id = (int) term_exists( 'guideline', 'wp_knowledge_type' )['term_id'];
+
+		$response = $this->create_row(
+			array(
+				'slug'              => 'guideline-images',
+				'title'             => 'Bogus client title',
+				'content'           => 'Square images only.',
+				'status'            => 'publish',
+				'wp_knowledge_type' => array( $guideline_id ),
+			)
+		);
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( 'Images', get_post( $response->get_data()['id'] )->post_title );
+	}
+
+	/**
 	 * A second create with an already-used `guideline-` slug is not rejected.
 	 * WordPress suffixes the slug, and the published row keeps the exact slug.
 	 *
 	 * @ticket 65476
-	 * @covers ::wp_guideline_restamp_scope_title
+	 * @covers ::wp_guideline_prepare_rest_row
 	 */
 	public function test_duplicate_slug_is_suffixed_not_rejected() {
 		wp_set_current_user( self::$admin_id );
@@ -95,11 +213,10 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * A content-only update of an existing row succeeds. The slug and title are
-	 * left untouched.
+	 * A content-only update of an existing row succeeds and stores the new content.
 	 *
 	 * @ticket 65476
-	 * @covers ::wp_guideline_sanitize_rest_content
+	 * @covers ::wp_guideline_prepare_rest_row
 	 */
 	public function test_content_only_update_succeeds() {
 		wp_set_current_user( self::$admin_id );
@@ -123,13 +240,13 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Registry scope titles are re-stamped from wp_guideline_scopes(), ignoring
-	 * any client-provided title.
+	 * Single-row scope titles are set from wp_guideline_scopes(), ignoring any
+	 * client-provided title.
 	 *
 	 * @ticket 65476
-	 * @covers ::wp_guideline_restamp_scope_title
+	 * @covers ::wp_guideline_prepare_rest_row
 	 */
-	public function test_scope_title_restamped_from_registry() {
+	public function test_sets_scope_title_from_registry() {
 		wp_set_current_user( self::$admin_id );
 
 		$response = $this->create_row(
@@ -146,10 +263,11 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Block rows keep the client-provided canonical block name as the title.
+	 * Per-block rows keep the client-provided canonical block name as the title,
+	 * because the blocks scope is multi-row.
 	 *
 	 * @ticket 65476
-	 * @covers ::wp_guideline_restamp_scope_title
+	 * @covers ::wp_guideline_prepare_rest_row
 	 */
 	public function test_block_row_keeps_canonical_title() {
 		wp_set_current_user( self::$admin_id );
@@ -168,10 +286,10 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 	}
 
 	/**
-	 * Content is sanitized to plain text and capped at the guideline length.
+	 * Content is reduced to plain text and capped at the guideline length.
 	 *
 	 * @ticket 65476
-	 * @covers ::wp_guideline_sanitize_rest_content
+	 * @covers ::wp_guideline_prepare_rest_row
 	 */
 	public function test_content_sanitized_and_capped() {
 		wp_set_current_user( self::$admin_id );
@@ -191,27 +309,5 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 
 		$this->assertStringNotContainsString( '<script', $content );
 		$this->assertLessThanOrEqual( 5000, mb_strlen( $content, 'UTF-8' ) );
-	}
-
-	/**
-	 * The scope title is re-stamped even when the row is created outside REST,
-	 * because the invariant is enforced on the generic save path.
-	 *
-	 * @ticket 65476
-	 * @covers ::wp_guideline_restamp_scope_title
-	 */
-	public function test_scope_title_restamped_on_direct_insert() {
-		$post_id = wp_insert_post(
-			array(
-				'post_type'    => 'wp_knowledge',
-				'post_status'  => 'private',
-				'post_name'    => 'guideline-copy',
-				'post_title'   => 'Bogus title',
-				'post_content' => 'Be concise.',
-			)
-		);
-
-		$this->assertGreaterThan( 0, $post_id );
-		$this->assertSame( 'Copy', get_post( $post_id )->post_title );
 	}
 }

--- a/tests/phpunit/tests/guidelines/reservation.php
+++ b/tests/phpunit/tests/guidelines/reservation.php
@@ -99,7 +99,7 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 
 		$response = $this->create_row(
 			array(
-				'slug'    => 'guideline-block-core-paragraph',
+				'slug'    => 'guideline-block-core_paragraph',
 				'title'   => 'core/paragraph',
 				'content' => 'Keep paragraphs short.',
 				'status'  => 'publish',
@@ -274,7 +274,7 @@ class Tests_Guidelines_Reservation extends WP_Test_REST_TestCase {
 
 		$response = $this->create_row(
 			array(
-				'slug'    => 'guideline-block-core-paragraph',
+				'slug'    => 'guideline-block-core_paragraph',
 				'title'   => 'core/paragraph',
 				'content' => 'Keep paragraphs short.',
 				'status'  => 'publish',

--- a/tests/phpunit/tests/guidelines/scopes.php
+++ b/tests/phpunit/tests/guidelines/scopes.php
@@ -16,7 +16,7 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 	public function test_default_scopes_are_registered() {
 		$scopes = wp_guideline_scopes();
 
-		$this->assertSame( array( 'site', 'copy', 'images', 'additional' ), array_keys( $scopes ) );
+		$this->assertSame( array( 'site', 'copy', 'images', 'blocks', 'additional' ), array_keys( $scopes ) );
 
 		foreach ( $scopes as $scope ) {
 			$this->assertArrayHasKey( 'title', $scope );
@@ -33,18 +33,19 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 	 * @covers ::wp_guideline_scopes
 	 */
 	public function test_scopes_are_filterable() {
-		$callback = static function ( $scopes ) {
-			$scopes['custom'] = array(
-				'title'       => 'Custom',
-				'description' => 'Custom scope.',
-				'order'       => 99,
-			);
-			return $scopes;
-		};
+		add_filter(
+			'wp_guideline_scopes',
+			static function ( $scopes ) {
+				$scopes['custom'] = array(
+					'title'       => 'Custom',
+					'description' => 'Custom scope.',
+					'order'       => 99,
+				);
+				return $scopes;
+			}
+		);
 
-		add_filter( 'wp_guideline_scopes', $callback );
 		$scopes = wp_guideline_scopes();
-		remove_filter( 'wp_guideline_scopes', $callback );
 
 		$this->assertArrayHasKey( 'custom', $scopes );
 		$this->assertSame( 'Custom', $scopes['custom']['title'] );
@@ -63,13 +64,14 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 	 * @covers ::wp_guideline_max_length
 	 */
 	public function test_max_length_is_filterable() {
-		$callback = static function () {
-			return 10;
-		};
+		add_filter(
+			'wp_guideline_max_length',
+			static function () {
+				return 10;
+			}
+		);
 
-		add_filter( 'wp_guideline_max_length', $callback );
 		$max = wp_guideline_max_length();
-		remove_filter( 'wp_guideline_max_length', $callback );
 
 		$this->assertSame( 10, $max );
 	}

--- a/tests/phpunit/tests/guidelines/scopes.php
+++ b/tests/phpunit/tests/guidelines/scopes.php
@@ -81,7 +81,7 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 			'registry scope'   => array( 'guideline-site', 'site' ),
 			'another scope'    => array( 'guideline-images', 'images' ),
 			'blocks scope'     => array( 'guideline-blocks', 'blocks' ),
-			'block row'        => array( 'guideline-block-core-paragraph', 'blocks' ),
+			'block row'        => array( 'guideline-block-core_paragraph', 'blocks' ),
 			'empty block name' => array( 'guideline-block-', null ),
 			'unknown scope'    => array( 'guideline-nope', null ),
 			'bare prefix'      => array( 'guideline-', null ),
@@ -109,7 +109,7 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 	 * @covers ::wp_guideline_scope_from_slug
 	 */
 	public function test_block_row_scope_requires_blocks_scope() {
-		$this->assertSame( 'blocks', wp_guideline_scope_from_slug( 'guideline-block-core-paragraph' ) );
+		$this->assertSame( 'blocks', wp_guideline_scope_from_slug( 'guideline-block-core_paragraph' ) );
 
 		add_filter(
 			'wp_guideline_scopes',
@@ -119,6 +119,44 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 			}
 		);
 
-		$this->assertNull( wp_guideline_scope_from_slug( 'guideline-block-core-paragraph' ) );
+		$this->assertNull( wp_guideline_scope_from_slug( 'guideline-block-core_paragraph' ) );
+	}
+
+	/**
+	 * A registered scope keyed under `block-` wins over the per-block namespace.
+	 *
+	 * Real per-block slugs always encode the block namespace separator as `_`
+	 * (`core/paragraph` becomes `guideline-block-core_paragraph`), so a scope key
+	 * made only of hyphens like `block-editor-media-instructions` never matches a
+	 * real block row. That is why the collision is very unlikely in practice.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_scope_from_slug
+	 */
+	public function test_registered_scope_wins_over_block_namespace() {
+		$slug = 'guideline-block-editor-media-instructions';
+
+		// Before the scope exists the slug looks like a per-block row, so it is
+		// swallowed by the blocks scope.
+		$this->assertSame( 'blocks', wp_guideline_scope_from_slug( $slug ) );
+
+		add_filter(
+			'wp_guideline_scopes',
+			static function ( $scopes ) {
+				$scopes['block-editor-media-instructions'] = array(
+					'title'       => 'Media instructions',
+					'description' => '',
+					'order'       => 60,
+				);
+				return $scopes;
+			}
+		);
+
+		// Once registered, the exact scope key wins and resolves to itself.
+		$this->assertSame( 'block-editor-media-instructions', wp_guideline_scope_from_slug( $slug ) );
+
+		// A real per-block row keeps the namespace separator as `_`, so it never
+		// collides with such a scope key and still resolves to the blocks scope.
+		$this->assertSame( 'blocks', wp_guideline_scope_from_slug( 'guideline-block-core_paragraph' ) );
 	}
 }

--- a/tests/phpunit/tests/guidelines/scopes.php
+++ b/tests/phpunit/tests/guidelines/scopes.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Tests for the guideline scopes registry and slug helpers.
+ *
+ * @package WordPress
+ * @subpackage Guidelines
+ *
+ * @group guidelines
+ */
+class Tests_Guidelines_Scopes extends WP_UnitTestCase {
+
+	/**
+	 * @ticket 65476
+	 * @covers ::wp_guideline_scopes
+	 */
+	public function test_default_scopes_are_registered() {
+		$scopes = wp_guideline_scopes();
+
+		$this->assertSame( array( 'site', 'copy', 'images', 'additional' ), array_keys( $scopes ) );
+
+		foreach ( $scopes as $scope ) {
+			$this->assertArrayHasKey( 'title', $scope );
+			$this->assertArrayHasKey( 'description', $scope );
+			$this->assertArrayHasKey( 'order', $scope );
+			$this->assertIsInt( $scope['order'] );
+		}
+
+		$this->assertSame( 'Site', $scopes['site']['title'] );
+	}
+
+	/**
+	 * @ticket 65476
+	 * @covers ::wp_guideline_scopes
+	 */
+	public function test_scopes_are_filterable() {
+		$callback = static function ( $scopes ) {
+			$scopes['custom'] = array(
+				'title'       => 'Custom',
+				'description' => 'Custom scope.',
+				'order'       => 99,
+			);
+			return $scopes;
+		};
+
+		add_filter( 'wp_guideline_scopes', $callback );
+		$scopes = wp_guideline_scopes();
+		remove_filter( 'wp_guideline_scopes', $callback );
+
+		$this->assertArrayHasKey( 'custom', $scopes );
+		$this->assertSame( 'Custom', $scopes['custom']['title'] );
+	}
+
+	/**
+	 * @ticket 65476
+	 * @covers ::wp_guideline_max_length
+	 */
+	public function test_max_length_defaults_to_5000() {
+		$this->assertSame( 5000, wp_guideline_max_length() );
+	}
+
+	/**
+	 * @ticket 65476
+	 * @covers ::wp_guideline_max_length
+	 */
+	public function test_max_length_is_filterable() {
+		$callback = static function () {
+			return 10;
+		};
+
+		add_filter( 'wp_guideline_max_length', $callback );
+		$max = wp_guideline_max_length();
+		remove_filter( 'wp_guideline_max_length', $callback );
+
+		$this->assertSame( 10, $max );
+	}
+
+	public function data_scope_from_slug(): array {
+		return array(
+			'registry scope'  => array( 'guideline-site', 'site' ),
+			'another scope'   => array( 'guideline-images', 'images' ),
+			'block row'       => array( 'guideline-block-core-paragraph', null ),
+			'unknown scope'   => array( 'guideline-nope', null ),
+			'not a guideline' => array( 'note-site', null ),
+		);
+	}
+
+	/**
+	 * @ticket 65476
+	 * @covers ::wp_guideline_scope_from_slug
+	 *
+	 * @dataProvider data_scope_from_slug
+	 *
+	 * @param string      $slug     Post slug.
+	 * @param string|null $expected Expected scope key.
+	 */
+	public function test_scope_from_slug( $slug, $expected ) {
+		$this->assertSame( $expected, wp_guideline_scope_from_slug( $slug ) );
+	}
+}

--- a/tests/phpunit/tests/guidelines/scopes.php
+++ b/tests/phpunit/tests/guidelines/scopes.php
@@ -78,11 +78,14 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 
 	public function data_scope_from_slug(): array {
 		return array(
-			'registry scope'  => array( 'guideline-site', 'site' ),
-			'another scope'   => array( 'guideline-images', 'images' ),
-			'block row'       => array( 'guideline-block-core-paragraph', null ),
-			'unknown scope'   => array( 'guideline-nope', null ),
-			'not a guideline' => array( 'note-site', null ),
+			'registry scope'   => array( 'guideline-site', 'site' ),
+			'another scope'    => array( 'guideline-images', 'images' ),
+			'blocks scope'     => array( 'guideline-blocks', 'blocks' ),
+			'block row'        => array( 'guideline-block-core-paragraph', 'blocks' ),
+			'empty block name' => array( 'guideline-block-', null ),
+			'unknown scope'    => array( 'guideline-nope', null ),
+			'bare prefix'      => array( 'guideline-', null ),
+			'not a guideline'  => array( 'note-site', null ),
 		);
 	}
 
@@ -97,5 +100,25 @@ class Tests_Guidelines_Scopes extends WP_UnitTestCase {
 	 */
 	public function test_scope_from_slug( $slug, $expected ) {
 		$this->assertSame( $expected, wp_guideline_scope_from_slug( $slug ) );
+	}
+
+	/**
+	 * Per-block rows resolve to the blocks scope only while it is registered.
+	 *
+	 * @ticket 65476
+	 * @covers ::wp_guideline_scope_from_slug
+	 */
+	public function test_block_row_scope_requires_blocks_scope() {
+		$this->assertSame( 'blocks', wp_guideline_scope_from_slug( 'guideline-block-core-paragraph' ) );
+
+		add_filter(
+			'wp_guideline_scopes',
+			static function ( $scopes ) {
+				unset( $scopes['blocks'] );
+				return $scopes;
+			}
+		);
+
+		$this->assertNull( wp_guideline_scope_from_slug( 'guideline-block-core-paragraph' ) );
 	}
 }

--- a/tests/phpunit/tests/rest-api/rest-schema-setup.php
+++ b/tests/phpunit/tests/rest-api/rest-schema-setup.php
@@ -112,6 +112,7 @@ class WP_Test_REST_Schema_Initialization extends WP_Test_REST_TestCase {
 			'/wp/v2/knowledge/(?P<id>[\\d]+)',
 			'/wp/v2/knowledge/(?P<parent>[\\d]+)/revisions',
 			'/wp/v2/knowledge/(?P<parent>[\\d]+)/revisions/(?P<id>[\\d]+)',
+			'/wp/v2/knowledge/guideline-scopes',
 			'/wp/v2/media',
 			'/wp/v2/media/(?P<id>[\\d]+)',
 			'/wp/v2/media/(?P<id>[\\d]+)/post-process',

--- a/tests/phpunit/tests/rest-api/wpRestGuidelineScopesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestGuidelineScopesController.php
@@ -58,7 +58,7 @@ class Tests_REST_WpRestGuidelineScopesController extends WP_Test_REST_TestCase {
 
 		$data  = $response->get_data();
 		$slugs = wp_list_pluck( $data, 'slug' );
-		$this->assertSame( array( 'site', 'copy', 'images', 'additional' ), $slugs );
+		$this->assertSame( array( 'site', 'copy', 'images', 'blocks', 'additional' ), $slugs );
 
 		$this->assertArrayHasKey( 'title', $data[0] );
 		$this->assertArrayHasKey( 'description', $data[0] );
@@ -76,21 +76,44 @@ class Tests_REST_WpRestGuidelineScopesController extends WP_Test_REST_TestCase {
 	public function test_filter_adds_scope() {
 		wp_set_current_user( self::$admin_id );
 
-		$callback = static function ( $scopes ) {
-			$scopes['custom'] = array(
-				'title'       => 'Custom',
-				'description' => 'Custom scope.',
-				'order'       => 99,
-			);
-			return $scopes;
-		};
-		add_filter( 'wp_guideline_scopes', $callback );
+		add_filter(
+			'wp_guideline_scopes',
+			static function ( $scopes ) {
+				$scopes['custom'] = array(
+					'title'       => 'Custom',
+					'description' => 'Custom scope.',
+					'order'       => 99,
+				);
+				return $scopes;
+			}
+		);
 
 		$data  = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp/v2/knowledge/guideline-scopes' ) )->get_data();
 		$slugs = wp_list_pluck( $data, 'slug' );
 
-		remove_filter( 'wp_guideline_scopes', $callback );
-
 		$this->assertContains( 'custom', $slugs );
+	}
+
+	/**
+	 * The wp_guideline_scopes filter is reflected in the response, so plugins
+	 * can remove a default scope.
+	 *
+	 * @ticket 65476
+	 */
+	public function test_filter_removes_scope() {
+		wp_set_current_user( self::$admin_id );
+
+		add_filter(
+			'wp_guideline_scopes',
+			static function ( $scopes ) {
+				unset( $scopes['blocks'] );
+				return $scopes;
+			}
+		);
+
+		$data  = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp/v2/knowledge/guideline-scopes' ) )->get_data();
+		$slugs = wp_list_pluck( $data, 'slug' );
+
+		$this->assertNotContains( 'blocks', $slugs );
 	}
 }

--- a/tests/phpunit/tests/rest-api/wpRestGuidelineScopesController.php
+++ b/tests/phpunit/tests/rest-api/wpRestGuidelineScopesController.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Unit tests covering WP_REST_Guideline_Scopes_Controller.
+ *
+ * @package WordPress
+ * @subpackage REST_API
+ *
+ * @group guidelines
+ * @group restapi
+ *
+ * @covers WP_REST_Guideline_Scopes_Controller
+ */
+class Tests_REST_WpRestGuidelineScopesController extends WP_Test_REST_TestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	protected static $admin_id;
+
+	public static function wpSetUpBeforeClass( WP_UnitTest_Factory $factory ) {
+		self::$admin_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
+
+	/**
+	 * @ticket 65476
+	 */
+	public function test_route_is_registered() {
+		$routes = rest_get_server()->get_routes();
+		$this->assertArrayHasKey( '/wp/v2/knowledge/guideline-scopes', $routes );
+	}
+
+	/**
+	 * Reads require the knowledge read capability, so logged-out users are denied.
+	 *
+	 * @ticket 65476
+	 */
+	public function test_read_requires_knowledge_read_capability() {
+		wp_set_current_user( 0 );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp/v2/knowledge/guideline-scopes' ) );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Administrators receive the default scopes keyed by slug with title,
+	 * description, and order fields.
+	 *
+	 * @ticket 65476
+	 */
+	public function test_get_items_returns_default_scopes_for_admin() {
+		wp_set_current_user( self::$admin_id );
+
+		$response = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp/v2/knowledge/guideline-scopes' ) );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data  = $response->get_data();
+		$slugs = wp_list_pluck( $data, 'slug' );
+		$this->assertSame( array( 'site', 'copy', 'images', 'additional' ), $slugs );
+
+		$this->assertArrayHasKey( 'title', $data[0] );
+		$this->assertArrayHasKey( 'description', $data[0] );
+		$this->assertArrayHasKey( 'order', $data[0] );
+		$this->assertSame( 'Site', $data[0]['title'] );
+		$this->assertIsInt( $data[0]['order'] );
+	}
+
+	/**
+	 * The wp_guideline_scopes filter is reflected in the response, so plugins
+	 * can register additional scopes.
+	 *
+	 * @ticket 65476
+	 */
+	public function test_filter_adds_scope() {
+		wp_set_current_user( self::$admin_id );
+
+		$callback = static function ( $scopes ) {
+			$scopes['custom'] = array(
+				'title'       => 'Custom',
+				'description' => 'Custom scope.',
+				'order'       => 99,
+			);
+			return $scopes;
+		};
+		add_filter( 'wp_guideline_scopes', $callback );
+
+		$data  = rest_get_server()->dispatch( new WP_REST_Request( 'GET', '/wp/v2/knowledge/guideline-scopes' ) )->get_data();
+		$slugs = wp_list_pluck( $data, 'slug' );
+
+		remove_filter( 'wp_guideline_scopes', $callback );
+
+		$this->assertContains( 'custom', $slugs );
+	}
+}

--- a/tests/qunit/fixtures/wp-api-generated.js
+++ b/tests/qunit/fixtures/wp-api-generated.js
@@ -14017,6 +14017,27 @@ mockedApiResponse.Schema = {
                     }
                 ]
             }
+        },
+        "/wp/v2/knowledge/guideline-scopes": {
+            "namespace": "wp/v2",
+            "methods": [
+                "GET"
+            ],
+            "endpoints": [
+                {
+                    "methods": [
+                        "GET"
+                    ],
+                    "args": []
+                }
+            ],
+            "_links": {
+                "self": [
+                    {
+                        "href": "http://example.org/index.php?rest_route=/wp/v2/knowledge/guideline-scopes"
+                    }
+                ]
+            }
         }
     },
     "image_sizes": {


### PR DESCRIPTION
Trac ticket: https://core.trac.wordpress.org/ticket/65476

## Summary

Adds the **Guidelines** consumer layer on top of the `wp_knowledge` storage primitive from #12201. A guideline is a `wp_knowledge` row that carries the `guideline` type term and a `guideline-{scope}` slug. This PR lands the **server side only**. The Settings → Guidelines screen and its client app stay in the Gutenberg plugin and consume these routes.

It is stacked on `feature/knowledge-cpt` (#12201), so it targets that branch. Once Knowledge lands in trunk, this can be retargeted.

## What it adds

- **Scopes registry.** `wp_guideline_scopes()` returns the sections shown on a Guidelines screen (`site`, `copy`, `images`, `blocks`, `additional`), each with a title, description, and sort order. Plugins can register or remove scopes through the `wp_guideline_scopes` filter. `blocks` is the one exception in the registry: it has no single `guideline-blocks` row, and its guidelines live in the per-block `guideline-block-*` rows. `wp_guideline_scope_from_slug()` maps a row slug back to its scope, resolving both `guideline-{scope}` and per-block `guideline-block-*` rows (the latter to `blocks`). A registered scope key always wins, so a scope keyed like `block-*` resolves to itself rather than being treated as a per-block row. The content length cap is the filterable `wp_guideline_max_length()`.
- **REST route.** `WP_REST_Guideline_Scopes_Controller` serves the read-only `/wp/v2/knowledge/guideline-scopes` route, gated on `read_knowledge_items`. Guideline data itself is read and written through the standard `/wp/v2/knowledge` collection.
- **Guideline row shaping.** A single callback, `wp_guideline_prepare_rest_row()`, on the `rest_pre_insert_wp_knowledge` filter is the one place that shapes a guideline row. It acts only when two gates pass. First, the slug must map to a registered scope. Second, if the request selects any `wp_knowledge_type` terms, the `guideline` term must be among them, otherwise the row is not a guideline and is left untouched. When both gates pass it:
  - sets the `guideline` type when the request selects no term, creating the term on first use (the standard REST term handling assigns it after insert);
  - stamps a single-row scope title from the registry in the site locale (the multi-row `blocks` scope keeps each row's block-name title);
  - reduces the content to plain text and caps it at `wp_guideline_max_length()`.

  The callback follows the filter's `stdClass|WP_Error` contract: it passes a prior filter's error through untouched, and rejects the write with `rest_cannot_create_guideline_type` (status 500) if the `guideline` term cannot be created.

## Why one callback over REST

The Settings → Guidelines screen writes rows through the REST API, so the shaping lives at that boundary in a single place. Keeping the type, title, and content changes together behind one gate makes it easy to see that they apply uniformly and only to recognized guideline slugs, and that nothing else has to coordinate. A request that selects a non-guideline type, or a slug that is not a registered scope, is left untouched, as is any row written outside REST.

## Testing

```
npm run test:php -- --group guidelines
```

Covers the scopes registry and slug helpers (including per-block resolution to the `blocks` scope), the read-only REST route (permission gating, default scopes, filters that add and remove a scope), and the REST row shaping: the type is set when the request selects none; a selected type is kept when it includes the `guideline` term and the row is left untouched when it does not; the single-row scope title is stamped while per-block titles are preserved; slug uniqueness is handled; content is sanitized to plain text and capped; and the write is rejected when the `guideline` term cannot be created.

## Use of AI Tools

This pull request was authored with the help of Claude Code (Claude Opus 4.8). I reviewed all the changes and take responsibility for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

